### PR TITLE
Fix auth modes enabled by config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,8 +65,12 @@ func main() {
 
 		utils.ApplyFlags(cliFlags, flagMappings, c, appOptions, backendOptions)
 
-		appOptions.EnableBasicAuth = c.IsSet("credential")
-		appOptions.EnableTLSClientAuth = c.IsSet("tls-ca-crt")
+		if c.IsSet("credential") {
+			appOptions.EnableBasicAuth = true
+		}
+		if c.IsSet("tls-ca-crt") {
+			appOptions.EnableTLSClientAuth = true
+		}
 
 		err = appOptions.Validate()
 		if err != nil {


### PR DESCRIPTION
Currently, you can set `enable_basic_auth = true` or `enable_tls_client_auth = true` in the config file, but unless you also provide a credential via `-c` or a TLS CA certificate via `-tls-ca-crt` on the command line, it will disable basic auth and TLS client auth because it overrides `EnableBasicAuth` and `EnableTLSClientAuth` based solely on the presence of CLI options.

This fixes it so that the auth modes enabled by the config file are not disabled in the absence of the above CLI options.