### PR TITLE
update go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1
+FROM golang:1.16
 
 WORKDIR /gotty
 COPY . /gotty


### PR DESCRIPTION
executables build from go 1.16 builder
but docker still uses go 1.13 builder