### PR TITLE
Add quiet flag to disable logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -61,6 +62,11 @@ func main() {
 			if err := utils.ApplyConfigFile(configFile, appOptions, backendOptions); err != nil {
 				exit(err, 2)
 			}
+		}
+
+		if appOptions.Quiet {
+			log.SetFlags(0)
+			log.SetOutput(ioutil.Discard)
 		}
 
 		utils.ApplyFlags(cliFlags, flagMappings, c, appOptions, backendOptions)

--- a/server/options.go
+++ b/server/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	WSOrigin            string           `hcl:"ws_origin" flagName:"ws-origin" flagDescribe:"A regular expression that matches origin URLs to be accepted by WebSocket. No cross origin requests are acceptable by default" default:""`
 	Term                string           `hcl:"term" flagName:"term" flagDescribe:"Terminal name to use on the browser, one of xterm or hterm." default:"xterm"`
 	EnableWebGL         bool             `hcl:"enable_webgl" flagName:"enable-webgl" flagDescribe:"Enable WebGL renderer" default:"true"`
+	Quiet               bool             `hcl:"quiet" flagName:"quiet" flagDescribe:"Don't log" default:"false"`
 
 	TitleVariables map[string]interface{}
 }


### PR DESCRIPTION
I recently installed gotty on my device, but got annoyed that it prints text every time someone connects, which displays the text in my tmux session. So I added a flag to completely disable all logging, which can be used once everything is setup correctly. I also tried to to wrap all the `log` calls in an if statement, but the HTTP Server uses log as well, so for 0 output you need to disable logging completely.