### PR TITLE
Avoid HTTP 401 error on manifest.json due to CORS

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{{ .title }}</title>
-    <link rel="manifest" href="manifest.json">
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
     <link rel="icon" href="favicon.ico">
     <link rel="icon" href="icon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="./css/index.css" />


### PR DESCRIPTION
Because of CORS, the manifest.json request returns an HTTP 401 error.
Explaination: https://github.com/koajs/basic-auth/issues/19