### PR TITLE
Improve the default appearance and readability of the tty

### DIFF
--- a/js/src/MyModal.tsx
+++ b/js/src/MyModal.tsx
@@ -1,6 +1,7 @@
 import { createRef, Component, ComponentChildren } from "preact";
 import { Modal } from "bootstrap";
 import './bootstrap.scss';
+import './style.scss';
 
 interface ModalProps {
   children: ComponentChildren;

--- a/js/src/style.scss
+++ b/js/src/style.scss
@@ -1,0 +1,11 @@
+#terminal {
+  width: auto;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0;
+
+  .terminal {
+    padding: 5px;
+    height: 100%;
+  }
+}

--- a/js/src/xterm.tsx
+++ b/js/src/xterm.tsx
@@ -1,8 +1,36 @@
-import { Terminal, IDisposable } from "xterm";
+import { Terminal, IDisposable, ITerminalOptions, ITheme } from "xterm";
 import { FitAddon } from 'xterm-addon-fit';
 import { WebLinksAddon } from 'xterm-addon-web-links';
 import { WebglAddon } from 'xterm-addon-webgl';
 import { ZModemAddon } from "./zmodem";
+
+const termOptions = {
+    fontSize: 13,
+    fontFamily: 'Menlo For Powerline,Consolas,Liberation Mono,Menlo,Courier,monospace',
+    macOptionClickForcesSelection: true,
+    macOptionIsMeta: true,
+    theme: {
+        foreground: '#d4d4d4',
+        background: '#1e1e1e',
+        cursor: '#adadad',
+        black: '#000000',
+        red: '#d81e00',
+        green: '#5ea702',
+        yellow: '#cfae00',
+        blue: '#427ab3',
+        magenta: '#89658e',
+        cyan: '#00a7aa',
+        white: '#dbded8',
+        brightBlack: '#686a66',
+        brightRed: '#f54235',
+        brightGreen: '#99e343',
+        brightYellow: '#fdeb61',
+        brightBlue: '#84b0d8',
+        brightMagenta: '#bc94b7',
+        brightCyan: '#37e6e8',
+        brightWhite: '#f1f1f0',
+    } as ITheme,
+} as ITerminalOptions;
 
 export class OurXterm {
     // The HTMLElement that contains our terminal
@@ -27,7 +55,7 @@ export class OurXterm {
 
     constructor(elem: HTMLElement) {
         this.elem = elem;
-        this.term = new Terminal();
+        this.term = new Terminal(termOptions);
         this.fitAddOn = new FitAddon();
         this.zmodemAddon = new ZModemAddon({
             toTerminal: (x: Uint8Array) => this.term.write(x),


### PR DESCRIPTION
This is what gotty currently looks like: 
![Screen Shot 2022-05-18 at 20 51 29](https://user-images.githubusercontent.com/346340/169023626-c3303cd8-22fa-4fb1-a44a-e4d4c235b2ae.png)

As compared to [ttyd](https://github.com/tsl0922/ttyd):
![Screen Shot 2022-05-18 at 20 52 40](https://user-images.githubusercontent.com/346340/169023670-a8ffeb79-6753-4f94-b080-8b18dd127d92.png)

Aesthetics are complicated and there is a good helping of subjectivity to them but I personally think ttyd looks far more pleasing as well as more readable. Both use xterm.js but the reason ttyd looks different is that it uses the theme options to style xterm. Currently gotty just uses the default theme settings of xterm.js which I think are a bit clunky looking. 

Since “good artists borrow, great artists steal” I've taken [the values which ttyd use for styling xterm](https://github.com/tsl0922/ttyd/blob/2b4dbacc10f0db7fceb092ea42ea12cd9301f4aa/html/src/components/app.tsx) and added them to gotty. With that change gotty now looks like:
![Screen Shot 2022-05-18 at 20 51 53](https://user-images.githubusercontent.com/346340/169024074-15c76474-b8a3-472c-b4ee-cb957284b62a.png)

There's no reason why we have to use these values exactly tho if anyone thinks there's a better combination. 