### PR TITLE
Add gitlab action steps to build and push docker

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,7 +22,6 @@ jobs:
       with:
         go-version: 1.16
 
-
     - name: "Build & test"
       run: "make tools release-artifacts"
 
@@ -35,3 +34,21 @@ jobs:
         files: |
           LICENSE
           builds/dist/*
+
+    - uses: docker/setup-qemu-action@v1
+
+    - uses: docker/setup-buildx-action@v1
+
+    - uses: docker/login-action@v1
+      with:
+        username: "${{ secrets.DOCKER_HUB_USER }}"
+        password: "${{ secrets.DOCKER_HUB_TOKEN }}"
+
+    - name: "Build and push docker image"
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        push: true
+        tags: "${{ secrets.DOCKER_REPO }}:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
-FROM golang:1.16
+FROM node:16 as js-build
+WORKDIR /gotty
+COPY js /gotty/js
+COPY Makefile /gotty/
+RUN make bindata/static/js/gotty.js.map
 
+FROM golang:1.16 as go-build
 WORKDIR /gotty
 COPY . /gotty
+COPY --from=js-build /gotty/js/node_modules /gotty/js/node_modules
+COPY --from=js-build /gotty/bindata/static/js /gotty/bindata/static/js
 RUN CGO_ENABLED=0 make
 
 FROM alpine:latest
-
 RUN apk update && \
     apk upgrade && \
-    apk --no-cache add ca-certificates && \
-    apk add bash
+    apk --no-cache add ca-certificates bash
 WORKDIR /root
-COPY --from=0 /gotty/gotty /usr/bin/
+COPY --from=go-build /gotty/gotty /usr/bin/
 CMD ["gotty",  "-w", "bash"]


### PR DESCRIPTION
I'd love a docker image of gotty that I can easily pull from docker hub and searching for gotty on docker hub currently turns up [150 gotty repos](https://hub.docker.com/search?q=gotty) so it seems I'm not the only who'd like one. Unfortunately all the options on there at the moment are out-of-date/sketchy looking so I figure it would be good to have a more "official" image. I thought the simplest approach with the least amount of extra work you'd have to do to maintain it would be to add a build and push step to the pre-release ci workflow. If you're happy about adding this to the CI then you'd need to setup 3 github action secrets:

DOCKER_HUB_USER: the username of your docker hub account, presumably sorenisanerd
DOCKER_HUB_TOKEN: you can get an access token under account settings -> security in docker hub
DOCKER_REPO: the repository name of the image to be built, presumably sorenisanerd/gotty