### PR TITLE
Dockerfile crash if npm is not installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16
 
 WORKDIR /gotty
 COPY . /gotty
+RUN apt-get update && apt-get install -y nodejs npm
 RUN CGO_ENABLED=0 make
 
 FROM alpine:latest


### PR DESCRIPTION
If `npm` is not explicitly installed this happen:

```
[+] Building 3.5s (10/13)
 => [internal] load build definition from Dockerfile 0.0s
 => => transferring dockerfile: 371B            0.0s
 => [internal] load .dockerignore               0.0s
 => => transferring context: 2B                 0.0s
 => [internal] load metadata for docker.io/library/alpine:latest  1.5s
 => [internal] load metadata for docker.io/library/golang:1.16 1.5s
 => [stage-0 1/4] FROM docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e 0.0s
 => [stage-1 1/4] FROM docker.io/library/alpine:latest@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 0.0s
 => [internal] load build context 0.1s
 => => transferring context: 33.68kB 0.0s
 => CACHED [stage-0 2/4] WORKDIR /gotty 0.0s
 => [stage-0 3/4] COPY . /gotty  1.0s
 => ERROR [stage-0 4/4] RUN CGO_ENABLED=0 make 0.8s
------
 > [stage-0 4/4] RUN CGO_ENABLED=0 make:
------
executor failed running [/bin/sh -c CGO_ENABLED=0 make]: exit code: 2
```

With this change:
```
[+] Building 205.0s (15/15) FINISHED
=> [internal] load build definition from Dockerfile 0.0s
=> => transferring dockerfile: 369B              0.0s
=> [internal] load .dockerignore                 0.0s
=> => transferring context: 2B                   0.0s
=> [internal] load metadata for docker.io/library/alpine:latest  0.7s
=> [internal] load metadata for docker.io/library/golang:1.16    0.6s
=> [internal] load build context                                 0.0s
=> => transferring context: 21.38kB                              0.0s
=> [stage-1 1/4] FROM docker.io/library/alpine:latest@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 0.0s
=> [stage-0 1/5] FROM docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e 0.0s
=> CACHED [stage-0 2/5] WORKDIR /gotty 0.0s
=> [stage-0 3/5] COPY . /gotty  0.1s
=> [stage-0 4/5] RUN apt-get update && apt-get install -y nodejs npm 85.8s
=> [stage-0 5/5] RUN CGO_ENABLED=0 make 117.1s
=> CACHED [stage-1 2/4] RUN apk update &&     apk upgrade &&     apk --no-cache add ca-certificates &&     apk add bash0.0s
=> CACHED [stage-1 3/4] WORKDIR /root 0.0s
=> CACHED [stage-1 4/4] COPY --from=0 /gotty/gotty /usr/bin/ 0.0s
=> exporting to image                                        0.0s
=> => exporting layers                                       0.0s
=> => writing image sha256:db7ee1fd2d2a37a6db77c05f7a6c6c3e2b37acc0deb3dcc458f652c057a27173  0.0s
=> => naming to docker.io/library/gotty
```