### PR TITLE
Add API to get current number of WebSocket connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gotty
 builds
 js/dist
 js/node_modules/*
+.idea/*

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ To share your current session with others by a shortcut key, you can add a line 
 bind-key C-t new-window "gotty tmux attach -t `tmux display -p '#S'`"
 ```
 
+### Signal Notify
+
+GoTTY have registered `SIGINT`, `SIGTERM` and `SIGUSR1` signal.
+
+* `SIGINT`, `SIGTERM`: will terminate process or terminate it gracefully.
+* `SIGUSR1`: logging current connection number if activated number is not 0, or will send `SIGINT` signal. Especially useful in releasing resource according to your requirement.
+
 ## Playing with Docker
 
 When you want to create a jailed environment for each client, you can use Docker containers like following:


### PR DESCRIPTION
* Background:

I want to kill gotty main process to release resources if not one use it, so required a method to get current WebSocket connections number

About use it definition:
* open in browser even without any input command. Or without any operation
* have any operations


Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>