### PR TITLE
Log user's writes in the TTY

### DIFF
--- a/.gotty
+++ b/.gotty
@@ -7,6 +7,9 @@
 // [bool] Permit clients to write to the TTY
 // permit_write = false
 
+// [bool] Log user's writes in the TTY
+// write_log = false
+
 // [bool] Enable basic authentication
 // enable_basic_auth = false
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When you want to create a jailed environment for each client, you can use Docker
 $ gotty -w docker run -it --rm busybox
 ```
 
-## Operation log
+## Writes log
 
 User's input in terminal can be found in logs. for example:
 
@@ -164,7 +164,7 @@ if you run gotty like this:
 this is `test.sh`:
 
 ```sh
-# !/bin/bash
+#!/bin/bash
 
 echo "Welcome: $4"
 kubectl -n $1 exec -it $2 -c $3 -- sh
@@ -174,12 +174,12 @@ visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=s
 
 ```
 ...
-2022/11/13 10:48:12 [oplog] lsCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
-2022/11/13 10:48:14 [oplog] pwdCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
+2022/11/13 10:48:12 [wlog] lsCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
+2022/11/13 10:48:14 [wlog] pwdCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
 ...
 ```
 
-Using the `[oplog]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
+Using the `[wlog]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,36 @@ When you want to create a jailed environment for each client, you can use Docker
 $ gotty -w docker run -it --rm busybox
 ```
 
+## Operation log
+
+User's input in terminal can be found in logs. for example:
+
+if you run gotty like this:
+
+```shell
+./gotty -w --permit-arguments ./test.sh
+```
+
+this is `test.sh`:
+
+```sh
+# !/bin/bash
+
+echo "Welcome: $4"
+kubectl -n $1 exec -it $2 -c $3 -- sh
+```
+
+visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=sleep&arg=21001713` and input your commands in shell, and you will see operation logs in stdout:
+
+```
+...
+2022/11/13 10:48:12 [oplog] lsCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
+2022/11/13 10:48:14 [oplog] pwdCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
+...
+```
+
+Using the `[oplog]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
+
 ## Development
 
 You can build a binary by simply running `make`. go1.16 is required.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
    --port value, -p value        Port number to liten (default: "8080") [$GOTTY_PORT]
    --path value, -m value        Base path (default: "/") [$GOTTY_PATH]
    --permit-write, -w            Permit clients to write to the TTY (BE CAREFUL) (default: false) [$GOTTY_PERMIT_WRITE]
+   --write-log                   Log user's writes in the TTY (default: false) [$GOTTY_WRITE_LOG]
    --credential value, -c value  Credential for Basic Authentication (ex: user:pass, default disabled) [$GOTTY_CREDENTIAL]
    --random-url, -r              Add a random string to the URL (default: false) [$GOTTY_RANDOM_URL]
    --random-url-length value     Random URL length (default: 8) [$GOTTY_RANDOM_URL_LENGTH]
@@ -151,14 +152,14 @@ When you want to create a jailed environment for each client, you can use Docker
 $ gotty -w docker run -it --rm busybox
 ```
 
-## Writes log
+## Write log
 
-User's input in terminal can be found in logs. for example:
+If you set `--write-log` option, user's writes in the TTY can be Logged. for example:
 
 if you run gotty like this:
 
 ```shell
-./gotty -w --permit-arguments ./test.sh
+./gotty -w --write-log --permit-arguments ./test.sh
 ```
 
 this is `test.sh`:
@@ -170,16 +171,16 @@ echo "Welcome: $4"
 kubectl -n $1 exec -it $2 -c $3 -- sh
 ```
 
-visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=sleep&arg=21001713` and input your commands in shell, and you will see operation logs in stdout:
+visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=sleep&arg=21001713` and input your commands in shell, and you will see user's writes in the log (operation logs):
 
 ```
 ...
-2022/11/13 10:48:12 [wlog] lsCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
-2022/11/13 10:48:14 [wlog] pwdCR {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]}
+2022/11/13 10:48:12 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} lsCR
+2022/11/13 10:48:14 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} pwdCR
 ...
 ```
 
-Using the `[wlog]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
+Using the `[write-log]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=s
 
 ```
 ...
-2022/11/13 10:48:12 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} lsCR
-2022/11/13 10:48:14 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} pwdCR
+2022/12/13 13:36:46 [write-log] map[arg:[without-istio sleep-7b6d569576-8nz7t sleep 21001713]] ls[CR]
+2022/12/13 13:37:25 [write-log] map[arg:[without-istio sleep-7b6d569576-8nz7t sleep 21001713]] echo[SPACE]hello[SPACE]world;[CR]
+2022/12/13 13:47:00 [write-log] map[arg:[without-istio sleep-7b6d569576-8nz7t sleep 21001713]] [CUU][CR]
 ...
 ```
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -150,6 +150,9 @@ func (server *Server) processWSConn(ctx context.Context, conn *websocket.Conn, h
 	if server.options.PermitWrite {
 		opts = append(opts, webtty.WithPermitWrite())
 	}
+	if server.options.WriteLog {
+		opts = append(opts, webtty.WithWriteLog())
+	}
 	if server.options.EnableReconnect {
 		opts = append(opts, webtty.WithReconnect(server.options.ReconnectTime))
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -145,6 +145,7 @@ func (server *Server) processWSConn(ctx context.Context, conn *websocket.Conn, h
 
 	opts := []webtty.Option{
 		webtty.WithWindowTitle(titleBuf.Bytes()),
+		webtty.WithArguments(params),
 	}
 	if server.options.PermitWrite {
 		opts = append(opts, webtty.WithPermitWrite())

--- a/server/options.go
+++ b/server/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	Port                string `hcl:"port" flagName:"port" flagSName:"p" flagDescribe:"Port number to liten" default:"8080"`
 	Path                string `hcl:"path" flagName:"path" flagSName:"m" flagDescribe:"Base path" default:"/"`
 	PermitWrite         bool   `hcl:"permit_write" flagName:"permit-write" flagSName:"w" flagDescribe:"Permit clients to write to the TTY (BE CAREFUL)" default:"false"`
+	WriteLog            bool   `hcl:"write_log" flagName:"write-log" flagDescribe:"Log user's writes in the TTY" default:"false"`
 	EnableBasicAuth     bool   `hcl:"enable_basic_auth" default:"false"`
 	Credential          string `hcl:"credential" flagName:"credential" flagSName:"c" flagDescribe:"Credential for Basic Authentication (ex: user:pass, default disabled)" default:""`
 	EnableRandomUrl     bool   `hcl:"enable_random_url" flagName:"random-url" flagSName:"r" flagDescribe:"Add a random string to the URL" default:"false"`

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,6 +1,6 @@
 package utils
 
-func FormatWriteLog(line *[]byte) (log string) {
+func FormatWritesLog(line *[]byte) (log string) {
 	ascii := map[byte]string{
 		0:   "NUL",
 		1:   "SOH",

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,7 +1,35 @@
 package utils
 
-func FormatWritesLog(line *[]byte) (log string) {
-	ascii := map[byte]string{
+import "fmt"
+
+func FormatWritesLog(codes []byte, line *string) {
+	n := len(codes)
+	str := ""
+	exist := false
+	if n == 3 {
+		if str, exist = ASCIIGroupToStr(fmt.Sprintf("%X", codes)); exist {
+			*line += str
+			codes = nil
+		}
+	}
+	// sh line prefix
+	if n >= 6 {
+		if str, exist = ASCIIGroupToStr(fmt.Sprintf("%X", []byte{codes[0], codes[1], codes[n-1]})); exist {
+			*line += str
+			codes = nil
+		}
+	}
+
+	if codes != nil {
+		str = ASCIIToStr(codes)
+		*line += str
+	}
+
+	return
+}
+
+func ASCIIToStr(codes []byte) string {
+	control := map[byte]string{
 		0:   "NUL",
 		1:   "SOH",
 		2:   "STX",
@@ -36,13 +64,32 @@ func FormatWritesLog(line *[]byte) (log string) {
 		31:  "US",
 		127: "DEL",
 	}
-	for _, word := range *line {
-		if value, ok := ascii[word]; ok {
-			log += value
-			continue
-		}
 
-		log += string(word)
+	str := ""
+	for _, code := range codes {
+		if value, ok := control[code]; ok {
+			str += value
+		} else {
+			str += string(code)
+		}
 	}
-	return
+
+	return str
+}
+
+func ASCIIGroupToStr(sum string) (string, bool) {
+	group := map[string]string{
+		"1B5B41": "UP",
+		"1B5B42": "DOWN",
+		"1B5B43": "RIGHT",
+		"1B5B44": "LEFT",
+		// sh line prefix: codes[0]codes[1]codes[5]
+		// eg. "ESC[ 1;5 R"
+		"1B5B52": "",
+	}
+	if value, ok := group[sum]; ok {
+		return value, true
+	}
+
+	return "", false
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,8 +1,8 @@
 package utils
 
-func FormatOperationLog(line *[]byte) (log string) {
+func FormatWriteLog(line *[]byte) (log string) {
 	ascii := map[byte]string{
-		0:   "", //NUL
+		0:   "NUL",
 		1:   "SOH",
 		2:   "STX",
 		3:   "ETX",

--- a/utils/log.go
+++ b/utils/log.go
@@ -12,7 +12,7 @@ func FormatWritesLog(codes []byte, line *string) {
 			codes = nil
 		}
 	}
-	// sh line prefix
+	// sh control codes
 	if n >= 6 {
 		if str, exist = ASCIIGroupToStr(fmt.Sprintf("%X", []byte{codes[0], codes[1], codes[n-1]})); exist {
 			*line += str
@@ -62,6 +62,7 @@ func ASCIIToStr(codes []byte) string {
 		29:  "GS",
 		30:  "RS",
 		31:  "US",
+		32:  "SPACE",
 		127: "DEL",
 	}
 
@@ -83,7 +84,7 @@ func ASCIIGroupToStr(sum string) (string, bool) {
 		"1B5B42": "DOWN",
 		"1B5B43": "RIGHT",
 		"1B5B44": "LEFT",
-		// sh line prefix: codes[0]codes[1]codes[5]
+		// sh control codes: codes[0]codes[1]codes[5]
 		// eg. "ESC[ 1;5 R"
 		"1B5B52": "",
 	}

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,0 +1,48 @@
+package utils
+
+func FormatOperationLog(line *[]byte) (log string) {
+	ascii := map[byte]string{
+		0:   "", //NUL
+		1:   "SOH",
+		2:   "STX",
+		3:   "ETX",
+		4:   "EOT",
+		5:   "ENQ",
+		6:   "ACK",
+		7:   "BEL",
+		8:   "BS",
+		9:   "HT",
+		10:  "LF",
+		11:  "VT",
+		12:  "FF",
+		13:  "CR",
+		14:  "SO",
+		15:  "SI",
+		16:  "DLE",
+		17:  "DCI",
+		18:  "DC2",
+		19:  "DC3",
+		20:  "DC4",
+		21:  "NAK",
+		22:  "SYN",
+		23:  "TB",
+		24:  "CAN",
+		25:  "EM",
+		26:  "SUB",
+		27:  "ESC",
+		28:  "FS",
+		29:  "GS",
+		30:  "RS",
+		31:  "US",
+		127: "DEL",
+	}
+	for _, word := range *line {
+		if value, ok := ascii[word]; ok {
+			log += value
+			continue
+		}
+
+		log += string(word)
+	}
+	return
+}

--- a/utils/log.go
+++ b/utils/log.go
@@ -2,93 +2,102 @@ package utils
 
 import "fmt"
 
-func FormatWritesLog(codes []byte, line *string) {
+var CtrlChar = map[byte]string{
+	0:   "NUL",
+	1:   "SOH",
+	2:   "STX",
+	3:   "ETX",
+	4:   "EOT",
+	5:   "ENQ",
+	6:   "ACK",
+	7:   "BEL",
+	8:   "BS",
+	9:   "HT",
+	10:  "LF",
+	11:  "VT",
+	12:  "FF",
+	13:  "CR",
+	14:  "SO",
+	15:  "SI",
+	16:  "DLE",
+	17:  "DCI",
+	18:  "DC2",
+	19:  "DC3",
+	20:  "DC4",
+	21:  "NAK",
+	22:  "SYN",
+	23:  "TB",
+	24:  "CAN",
+	25:  "EM",
+	26:  "SUB",
+	27:  "ESC",
+	28:  "FS",
+	29:  "GS",
+	30:  "RS",
+	31:  "US",
+	32:  "SPACE",
+	127: "DEL",
+}
+
+var CtrlCharGroup = map[string]string{
+	"1B5B41": "UP",
+	"1B5B42": "DOWN",
+	"1B5B43": "RIGHT",
+	"1B5B44": "LEFT",
+
+	// shell control codes
+	// codes[0]+codes[1]+codes[n-1]
+	// for example:
+	// [1B(ESC) 5B([) 32(2)       3B(;) 35(5) 52(R)]: row 2  col 5
+	// [1B(ESC) 5B([) 31(1) 30(0) 3B(;) 35(5) 52(R)]: row 10 col 5
+	// [1B(ESC) 5B([) 32(2) 32(2) 3B(;) 35(5) 52(R)]: row 22 col 5
+	"1B5B52": "",
+
+	// maybe there will be more control char group
+	// ...
+}
+
+func FormatWriteLog(codes []byte, line *string) {
 	n := len(codes)
-	str := ""
-	exist := false
+	// when user uses the keyboard arrow keys
+	// arrow keys are combination of 3 ASCII codes
 	if n == 3 {
-		if str, exist = ASCIIGroupToStr(fmt.Sprintf("%X", codes)); exist {
+		if str, exist := ASCIIGroupToStr(fmt.Sprintf("%X", codes)); exist {
 			*line += str
-			codes = nil
+			return
 		}
 	}
-	// sh control codes
+	// for some shells
+	// they will automatically send some control characters
+	// after typing the command and pressing Enter
+	// which indicate the current row and column.
 	if n >= 6 {
-		if str, exist = ASCIIGroupToStr(fmt.Sprintf("%X", []byte{codes[0], codes[1], codes[n-1]})); exist {
+		if str, exist := ASCIIGroupToStr(fmt.Sprintf("%X", []byte{codes[0], codes[1], codes[n-1]})); exist {
 			*line += str
-			codes = nil
+			return
 		}
 	}
 
-	if codes != nil {
-		str = ASCIIToStr(codes)
-		*line += str
-	}
+	str := ASCIIToStr(codes)
+	*line += str
 
 	return
 }
 
-func ASCIIToStr(codes []byte) string {
-	control := map[byte]string{
-		0:   "NUL",
-		1:   "SOH",
-		2:   "STX",
-		3:   "ETX",
-		4:   "EOT",
-		5:   "ENQ",
-		6:   "ACK",
-		7:   "BEL",
-		8:   "BS",
-		9:   "HT",
-		10:  "LF",
-		11:  "VT",
-		12:  "FF",
-		13:  "CR",
-		14:  "SO",
-		15:  "SI",
-		16:  "DLE",
-		17:  "DCI",
-		18:  "DC2",
-		19:  "DC3",
-		20:  "DC4",
-		21:  "NAK",
-		22:  "SYN",
-		23:  "TB",
-		24:  "CAN",
-		25:  "EM",
-		26:  "SUB",
-		27:  "ESC",
-		28:  "FS",
-		29:  "GS",
-		30:  "RS",
-		31:  "US",
-		32:  "SPACE",
-		127: "DEL",
-	}
-
-	str := ""
+func ASCIIToStr(codes []byte) (str string) {
 	for _, code := range codes {
-		if value, ok := control[code]; ok {
+		if value, ok := CtrlChar[code]; ok {
 			str += value
 		} else {
 			str += string(code)
 		}
 	}
 
-	return str
+	return
 }
 
-func ASCIIGroupToStr(sum string) (string, bool) {
-	group := map[string]string{
-		"1B5B41": "UP",
-		"1B5B42": "DOWN",
-		"1B5B43": "RIGHT",
-		"1B5B44": "LEFT",
-		// sh control codes: codes[0]codes[1]codes[5]
-		// eg. "ESC[ 1;5 R"
-		"1B5B52": "",
-	}
-	if value, ok := group[sum]; ok {
+func ASCIIGroupToStr(group string) (string, bool) {
+	if value, ok := CtrlCharGroup[group]; ok {
 		return value, true
 	}
 

--- a/webtty/option.go
+++ b/webtty/option.go
@@ -17,6 +17,14 @@ func WithPermitWrite() Option {
 	}
 }
 
+// WithWriteLog sets a WebTTY to log user's writes in the TTY.
+func WithWriteLog() Option {
+	return func(wt *WebTTY) error {
+		wt.writeLog = true
+		return nil
+	}
+}
+
 // WithFixedColumns sets a fixed width to TTY master.
 func WithFixedColumns(columns int) Option {
 	return func(wt *WebTTY) error {

--- a/webtty/option.go
+++ b/webtty/option.go
@@ -41,6 +41,14 @@ func WithWindowTitle(windowTitle []byte) Option {
 	}
 }
 
+// WithArguments sets the command line arguments that clients send
+func WithArguments(arguments map[string][]string) Option {
+	return func(wt *WebTTY) error {
+		wt.arguments = arguments
+		return nil
+	}
+}
+
 // WithReconnect enables reconnection on the master side.
 func WithReconnect(timeInSeconds int) Option {
 	return func(wt *WebTTY) error {

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"github.com/sorenisanerd/gotty/utils"
+	"log"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -21,6 +21,7 @@ type WebTTY struct {
 	slave Slave
 
 	windowTitle []byte
+	arguments   map[string][]string
 	permitWrite bool
 	columns     int
 	rows        int
@@ -188,9 +189,12 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *[]byte) error {
 		}
 
 		*line = append(*line, decodedBuffer[:n]...)
-		//fmt.Printf("master read: %v  -> %v\n", decodedBuffer[:n], string(decodedBuffer[:n]))
 		if decodedBuffer[n-1] == 13 {
-			fmt.Printf("master read line: %v\n", utils.FormatOperationLog(line))
+			argumentsByte, err := json.Marshal(wt.arguments)
+			if err != nil {
+				return errors.Wrapf(err, "failed to marshal arguments map")
+			}
+			log.Printf("[oplog] %s %s\n", utils.FormatOperationLog(line), string(argumentsByte))
 			*line = nil
 		}
 

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -98,17 +98,13 @@ func (wt *WebTTY) Run(ctx context.Context) error {
 		errs <- func() error {
 			buffer := make([]byte, wt.bufferSize)
 			var line string
-			arguments, err := json.Marshal(wt.arguments)
-			if err != nil {
-				return err
-			}
 			for {
 				n, err := wt.masterConn.Read(buffer)
 				if err != nil {
 					return ErrMasterClosed
 				}
 
-				err = wt.handleMasterReadEvent(buffer[:n], &line, arguments)
+				err = wt.handleMasterReadEvent(buffer[:n], &line)
 				if err != nil {
 					return err
 				}
@@ -177,7 +173,7 @@ func (wt *WebTTY) masterWrite(data []byte) error {
 	return nil
 }
 
-func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string, argument []byte) error {
+func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string) error {
 	if len(data) == 0 {
 		return errors.New("unexpected zero length read from master")
 	}
@@ -203,7 +199,7 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string, argument []by
 			// 13(ASCII) means carriage return(CR)
 			// it is the end of a line
 			if decodedBuffer[n-1] == 13 {
-				log.Printf("[write-log] %s %s\n", argument, *line)
+				log.Printf("[write-log] %v %s\n", wt.arguments, *line)
 				*line = ""
 			}
 		}

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -93,17 +93,13 @@ func (wt *WebTTY) Run(ctx context.Context) error {
 		errs <- func() error {
 			buffer := make([]byte, wt.bufferSize)
 			var line string
-			arguments, err := json.Marshal(wt.arguments)
-			if err != nil {
-				return err
-			}
 			for {
 				n, err := wt.masterConn.Read(buffer)
 				if err != nil {
 					return ErrMasterClosed
 				}
 
-				err = wt.handleMasterReadEvent(buffer[:n], &line, arguments)
+				err = wt.handleMasterReadEvent(buffer[:n], &line)
 				if err != nil {
 					return err
 				}
@@ -172,7 +168,7 @@ func (wt *WebTTY) masterWrite(data []byte) error {
 	return nil
 }
 
-func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string, argument []byte) error {
+func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string) error {
 	if len(data) == 0 {
 		return errors.New("unexpected zero length read from master")
 	}
@@ -198,7 +194,7 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string, argument []by
 			// 13(ASCII) means carriage return(CR)
 			// it is the end of a line
 			if decodedBuffer[n-1] == 13 {
-				log.Printf("[write-log] %s %s\n", argument, *line)
+				log.Printf("[write-log] %v %s\n", wt.arguments, *line)
 				*line = ""
 			}
 		}

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -194,7 +194,8 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *[]byte) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to marshal arguments map")
 			}
-			log.Printf("[oplog] %s %s\n", utils.FormatOperationLog(line), string(argumentsByte))
+			log.Printf("[wlog] %v\n", line)
+			log.Printf("[wlog] %s %s\n", utils.FormatWriteLog(line), string(argumentsByte))
 			*line = nil
 		}
 

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -23,6 +23,7 @@ type WebTTY struct {
 	windowTitle []byte
 	arguments   map[string][]string
 	permitWrite bool
+	writeLog    bool
 	columns     int
 	rows        int
 	reconnect   int // in seconds
@@ -91,14 +92,18 @@ func (wt *WebTTY) Run(ctx context.Context) error {
 	go func() {
 		errs <- func() error {
 			buffer := make([]byte, wt.bufferSize)
-			line := ""
+			var line string
+			arguments, err := json.Marshal(wt.arguments)
+			if err != nil {
+				return err
+			}
 			for {
 				n, err := wt.masterConn.Read(buffer)
 				if err != nil {
 					return ErrMasterClosed
 				}
 
-				err = wt.handleMasterReadEvent(buffer[:n], &line)
+				err = wt.handleMasterReadEvent(buffer[:n], &line, arguments)
 				if err != nil {
 					return err
 				}
@@ -167,7 +172,7 @@ func (wt *WebTTY) masterWrite(data []byte) error {
 	return nil
 }
 
-func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string) error {
+func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string, argument []byte) error {
 	if len(data) == 0 {
 		return errors.New("unexpected zero length read from master")
 	}
@@ -188,15 +193,14 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *string) error {
 			return errors.Wrapf(err, "failed to decode received data")
 		}
 
-		// log.Printf("[wlog] %v %X\n", decodedBuffer[:n], decodedBuffer[:n])
-		utils.FormatWritesLog(decodedBuffer[:n], line)
-		if decodedBuffer[n-1] == 13 {
-			argumentsByte, err := json.Marshal(wt.arguments)
-			if err != nil {
-				return errors.Wrapf(err, "failed to marshal arguments map")
+		if wt.writeLog {
+			utils.FormatWriteLog(decodedBuffer[:n], line)
+			// 13(ASCII) means carriage return(CR)
+			// it is the end of a line
+			if decodedBuffer[n-1] == 13 {
+				log.Printf("[write-log] %s %s\n", argument, *line)
+				*line = ""
 			}
-			log.Printf("[wlog] %s %s\n", *line, string(argumentsByte))
-			*line = ""
 		}
 
 		_, err = wt.slave.Write(decodedBuffer[:n])

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -194,7 +194,7 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *[]byte) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to marshal arguments map")
 			}
-			log.Printf("[wlog] %v\n", line)
+			//log.Printf("[wlog] %v\n", line)
 			log.Printf("[wlog] %s %s\n", utils.FormatWriteLog(line), string(argumentsByte))
 			*line = nil
 		}

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -195,7 +195,7 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte, line *[]byte) error {
 				return errors.Wrapf(err, "failed to marshal arguments map")
 			}
 			//log.Printf("[wlog] %v\n", line)
-			log.Printf("[wlog] %s %s\n", utils.FormatWriteLog(line), string(argumentsByte))
+			log.Printf("[wlog] %s %s\n", utils.FormatWritesLog(line), string(argumentsByte))
 			*line = nil
 		}
 


### PR DESCRIPTION
Sometimes, we want see the operations log in the terminal when enabled `-w`.

## Write log

If you set `--write-log` option, user's writes in the TTY can be Logged. for example:

if you run gotty like this:

```shell
./gotty -w --write-log --permit-arguments ./test.sh
```

this is `test.sh`:

```sh
#!/bin/bash

echo "Welcome: $4"
kubectl -n $1 exec -it $2 -c $3 -- sh
```

visit `http://127.0.0.1:8080/?arg=without-istio&arg=sleep-7b6d569576-57sjq&arg=sleep&arg=21001713` and input your commands in shell, and you will see user's writes in the log (operation logs):

```
...
2022/11/13 10:48:12 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} lsCR
2022/11/13 10:48:14 [write-log] {"arg":["without-istio","sleep-7b6d569576-57sjq","sleep","21001713"]} pwdCR
...
```

Using the `[write-log]` flag, you can collect and store these logs persistently. All args are in the log, including the userID. 
