### PR TITLE
fix: improve terminal rendering for box-drawing characters and custom fonts

### DIFF
--- a/js/src/xterm.tsx
+++ b/js/src/xterm.tsx
@@ -27,7 +27,10 @@ export class GoTTYXterm {
 
     constructor(elem: HTMLElement) {
         this.elem = elem;
-        this.term = new Terminal();
+        this.term = new Terminal({
+            customGlyphs: true,
+            rescaleOverlappingGlyphs: true,
+        });
         this.fitAddOn = new FitAddon();
         this.zmodemAddon = new ZModemAddon({
             toTerminal: (x: Uint8Array) => this.term.write(x),
@@ -48,6 +51,13 @@ export class GoTTYXterm {
         };
 
         this.term.open(elem);
+
+        try {
+            this.term.loadAddon(new WebglAddon());
+        } catch (e) {
+            console.warn("WebGL renderer failed to load, using canvas fallback", e);
+        }
+
         this.term.focus();
         this.resizeListener();
 
@@ -100,15 +110,25 @@ export class GoTTYXterm {
     };
 
     setPreferences(value: object) {
-        Object.keys(value).forEach((key) => {
-            if (key == "EnableWebGL" && key) {
-                this.term.loadAddon(new WebglAddon());
+        // Apply font settings before loading WebGL so the renderer
+        // initializes with the correct font metrics.
+        const keys = Object.keys(value);
+        const fontKeys = keys.filter(k => k === "font-family" || k === "font-size");
+        const otherKeys = keys.filter(k => k !== "font-family" && k !== "font-size");
+
+        for (const key of [...fontKeys, ...otherKeys]) {
+            if (key == "font-family") {
+                this.term.options.fontFamily = value[key];
             } else if (key == "font-size") {
-                this.term.options.fontSize = value[key]
-            } else if (key == "font-family") {
-                this.term.options.fontFamily = value[key]
+                this.term.options.fontSize = value[key];
+            } else if (key == "EnableWebGL") {
+                try {
+                    this.term.loadAddon(new WebglAddon());
+                } catch (e) {
+                    console.warn("WebGL renderer failed to load", e);
+                }
             }
-        });
+        }
     };
 
     sendInput(data: Uint8Array) {


### PR DESCRIPTION
## Summary

- Enable `customGlyphs` and `rescaleOverlappingGlyphs` in Terminal constructor so xterm.js draws pixel-perfect box-drawing and block element characters (U+2500–257F, U+2580–259F) instead of relying on font glyphs that may leave visible seams between rows
- Load WebGL renderer by default after `open()` with graceful canvas fallback — WebGL has better sub-pixel precision and eliminates rounding-related gaps between rows
- Reorder `setPreferences()` to apply `font-family` and `font-size` **before** loading the WebGL addon, so the renderer initializes with correct font metrics
- Wrap all WebGL addon loading in try/catch for devices without WebGL support

## Context

When using GoTTY with Nerd Fonts or Powerline-patched fonts, vertical box-drawing characters (`│`, `┃`, `║`) and table borders show visible gaps between rows. This is caused by:

1. xterm.js canvas renderer rounding cell heights, creating sub-pixel gaps
2. Font glyphs for box-drawing characters not extending to full cell boundaries
3. WebGL renderer (which handles this better) only being loaded via preferences, not by default
4. `setPreferences()` loading WebGL before applying font settings, causing the renderer to initialize with wrong font metrics

All changes are in `js/src/xterm.tsx` — single file, backward compatible.

## Test plan

- [ ] Verify box-drawing characters (`│`, `─`, `┌`, `┐`, `└`, `┘`) render without gaps
- [ ] Verify Powerline/Nerd Font separators (U+E0B0, U+E0B2) display correctly
- [ ] Verify graceful fallback on devices without WebGL
- [ ] Verify `font-family` / `font-size` preferences still work via `.gotty` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)