### PR TITLE
Bump Dockerfile golang image from 1.23 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY js /gotty/js
 COPY Makefile /gotty/
 RUN make bindata/static/js/gotty.js.map
 
-FROM golang:1.23 as go-build
+FROM golang:1.25 as go-build
 WORKDIR /gotty
 COPY . /gotty
 COPY --from=js-build /gotty/js/node_modules /gotty/js/node_modules


### PR DESCRIPTION
go.mod requires go >= 1.25.0 but Dockerfile was pinned to golang:1.23, causing the pre-release Docker build to fail with:
  go: go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)

Fixes the pre-release GitHub Actions workflow.