### PR TITLE
Add Dependabot config for Go + npm + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/js"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #85

Adds `.github/dependabot.yml` to automatically keep dependencies up to date:

- **Go modules** (go.mod) — weekly
- **npm** (/js/package.json) — weekly  
- **GitHub Actions** (workflow deps) — weekly